### PR TITLE
Intentional? Removed doubleclick action on semester text in header.

### DIFF
--- a/src/app/views/addModuleView.js
+++ b/src/app/views/addModuleView.js
@@ -40,9 +40,6 @@ define(function(require, exports) {
     function updateSemester() {
         $("#semester")
             .text("Year " + sem.acadYear + " SEM" + sem.semester)
-            .on("dblclick", function() {
-                $.publish("module:clean");
-            });
     }
 
     // term control buttons


### PR DESCRIPTION
This prevents accidental removal of the modules, especially when there's a clear module option implemented already. Got bitten by this bug (?) just now.
